### PR TITLE
Update ZenHub board link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hello!
 Welcome to the first Community Project that spans both Magento and Adobe Experience Platform!
 
-Here is our [ZenHub board](https://github.com/magento/axp-connector/wiki/_new#zenhub), best viewed with the Chrome ZenHub extension. Otherwise, our backlog is organized as a list of [issues](https://github.com/magento/axp-connector/issues).
+Here is our [ZenHub board](https://app.zenhub.com/workspace/o/magento/axp-connector/boards?repos=151743693), best viewed with the Chrome ZenHub extension. Otherwise, our backlog is organized as a list of [issues](https://github.com/magento/axp-connector/issues).
 
 Adobe Experience Cloud offers products that help merchants become more successful. Among these products are Adobe Analytics and Adobe Target which give merchants deep customer insights and the ability to deliver personalized experiences at scale. This project is meant to simplify the implementation of Adobe Experience Cloud products down to a few clicks so merchants have better access to this tools.
 


### PR DESCRIPTION
## Description
Existing ZenHub board link in Readme file is pointing to a wrong location. This Pull Request fixes the issue.